### PR TITLE
fix POST directly using bug

### DIFF
--- a/src/handler.php
+++ b/src/handler.php
@@ -6,7 +6,7 @@ define('DEFAULT_LNAME', 'Gubin');
 define('DEFAULT_EMAIL', 'girls_like_stars@gmail.com');
 
 
-if (empty($_POST['first_name']) && empty($_POST['last_name']) && empty($_POST['email'])) {
+if (empty($_POST['first_name']) || empty($_POST['last_name']) || empty($_POST['email'])) {
     $first_name = DEFAULT_FNAME;
     $last_name = DEFAULT_LNAME;
     $email = DEFAULT_EMAIL;

--- a/src/handler.php
+++ b/src/handler.php
@@ -2,9 +2,16 @@
 
 define('CSV_PATH', '../data/requests.csv');
 
-$first_name = $_POST['first_name'];
-$last_name = $_POST['last_name'];
-$email = $_POST['email'];
+if ($_POST['first_name'] && $_POST['last_name'] && $_POST['email']) {
+    $first_name = $_POST['first_name'];
+    $last_name = $_POST['last_name'];
+    $email = $_POST['email'];
+} else {
+    $first_name = 'Andrey';
+    $last_name = 'Gubin';
+    $email = 'girls_like_stars@gmail.com';
+} 
+
 $request = [$first_name, $last_name, $email];
 
 function csvRead()

--- a/src/handler.php
+++ b/src/handler.php
@@ -1,15 +1,19 @@
 <?php
 
 define('CSV_PATH', '../data/requests.csv');
+define('DEFAULT_FNAME', 'Andrey');
+define('DEFAULT_LNAME', 'Gubin');
+define('DEFAULT_EMAIL', 'girls_like_stars@gmail.com');
 
-if ($_POST['first_name'] && $_POST['last_name'] && $_POST['email']) {
+
+if (empty($_POST['first_name']) && empty($_POST['last_name']) && empty($_POST['email'])) {
+    $first_name = DEFAULT_FNAME;
+    $last_name = DEFAULT_LNAME;
+    $email = DEFAULT_EMAIL;
+} else {
     $first_name = $_POST['first_name'];
     $last_name = $_POST['last_name'];
     $email = $_POST['email'];
-} else {
-    $first_name = 'Andrey';
-    $last_name = 'Gubin';
-    $email = 'girls_like_stars@gmail.com';
 } 
 
 $request = [$first_name, $last_name, $email];

--- a/src/handler.php
+++ b/src/handler.php
@@ -1,10 +1,11 @@
 <?php
 
-define('CSV_PATH', '../data/names.csv');
+define('CSV_PATH', '../data/requests.csv');
 
 $first_name = $_POST['first_name'];
 $last_name = $_POST['last_name'];
 $email = $_POST['email'];
+$request = [$first_name, $last_name, $email];
 
 function csvRead()
 {   
@@ -13,14 +14,6 @@ function csvRead()
     $items = [];
 
     while (!feof($fp)) {
-        // $line = fgetcsv($fp, 100, ',');
-        // $items[] = array_combine($headers, $line); 
-        // на последней итерации, функиця fgetcvs возвращает false и array_combine выдает ошибку, 
-        // поскольку ждет на вход два массива. очевидно все дело в последнее пустой строке в csv, по логике
-        // fgetcsv на ней должна вернуть масcив [null]
-        // если убрать пустую последнюю строку то все работает, но тогда записть в csv, дописывает линию в конец уже существующей строки
-        // https://github.com/polundra-org/lab-01/blob/main/src/traits/CsvReader.php вот тут аналогичный код. но он работате без этой ошибки, почему?
-
         $items[] = fgetcsv($fp, 100, ',');
     }
     
@@ -29,10 +22,10 @@ function csvRead()
     return $items;
 }
 
-function csvWrite()
-{
+function csvWrite(array $request)
+{   
     $fp = fopen(CSV_PATH, 'a+');
-    fputcsv($fp, $_POST, ',', '"', '', "\n");
+    fputcsv($fp, $request, ',');
     fclose($fp);
 }
 
@@ -52,7 +45,7 @@ function csvEmailExixst($email)
 if (csvEmailExixst($email)) {
     $message = true;
 } else {
-    csvWrite();
+    csvWrite($request);
     $message = false;
 }
 


### PR DESCRIPTION
goal  -  do not use in code directly whole array POST, coz it can lead to recording errors
solution - use only specific items

cases, when we have got more field then we need:

```
curl 'https://1aa3f530-da95-4da8-bdd8-ae49c4f2e726-00-j7lryh9wjewq.janeway.replit.dev/src/handler.php' -H 'Content-Type: application/x-www-form-urlencoded' --data-raw 'first_name=foo&last_name=foo&email=foo%40gmail.com&age=20&sex=male' -vvv -L 
```

```
curl 'https://1aa3f530-da95-4da8-bdd8-ae49c4f2e726-00-j7lryh9wjewq.janeway.replit.dev/src/handler.php' -H 'Content-Type: application/x-www-form-urlencoded' --data-raw 'first_name=bob&last_name=bob&email=bob%40gmail.com&age=40&sex=male&country=Burkina_Faso' -vvv -L
```
however we saved only specific fields:

![image](https://github.com/user-attachments/assets/a773a7b8-12b4-4607-a314-7327059295cb)


